### PR TITLE
Modify run script

### DIFF
--- a/run_with_browser.zsh
+++ b/run_with_browser.zsh
@@ -1,9 +1,29 @@
 #!/bin/zsh
 
-# cargo run
-cargo build
+TIMEOUT=300
+count=0
+PID=$$
+cmd="ps aux | grep ' target/debug/saint-sorting' | grep -v grep | wc -l"
+pn=$(eval $cmd)
+if [ $pn -eq 1 ]; then
+  echo "app already running; kill & run..."
+  pid=`ps aux | grep ' target/debug/saint-sorting' | grep -v grep | awk '{print $2}'`
+  kill -9 $pid
+fi
 (
-	sleep 1
-	google-chrome http://127.0.0.1:8080/app/top
+  while :
+  do
+    cmd2="ps $PID | wc -l"
+    pn2=$(eval $cmd2)
+    pn=$(eval $cmd)
+    if [ $pn2 -ne 2 ]; then # cargo run failed
+      exit 1
+    fi
+    if [ $pn -eq 1 ]; then
+      google-chrome http://127.0.0.1:8080/app/top
+      exit 0
+    fi
+    sleep 1
+  done
 )&
-./target/debug/saint-sorting
+cargo run


### PR DESCRIPTION
## Description
I modified `run_with_browser.zsh`  to deal with multiple situations, such as running parallel. 
If you run this script when the saint-sorting app running, the app is killed, and `cargo run` starts.

## Test performed
I confirmed working the script in some differential situations.