### PR TITLE
show read & read_list result on clothing page

### DIFF
--- a/src/contents/clothing/delete.rs
+++ b/src/contents/clothing/delete.rs
@@ -29,7 +29,7 @@ pub async fn clothing_delete(
             return saint_sorting::render(tmpl, &context, "top.html");
         }
     }
-    clothing_read_list_render(session, tmpl, &mut context).await
+    clothing_read_list_render(&session, tmpl, &mut context).await
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/contents/clothing/page_view.rs
+++ b/src/contents/clothing/page_view.rs
@@ -11,5 +11,5 @@ pub async fn clothing(
         return saint_sorting::render(tmpl, &context, "top.html");
     }
 
-    return clothing_read_list(session, tmpl).await;
+    clothing_read_list(session, tmpl).await
 }

--- a/src/contents/clothing/page_view.rs
+++ b/src/contents/clothing/page_view.rs
@@ -11,5 +11,5 @@ pub async fn clothing(
         return saint_sorting::render(tmpl, &context, "top.html");
     }
 
-    saint_sorting::render(tmpl, &context, "clothing.html")
+    return clothing_read_list(session, tmpl).await;
 }

--- a/src/contents/clothing/page_view.rs
+++ b/src/contents/clothing/page_view.rs
@@ -11,5 +11,5 @@ pub async fn clothing(
         return saint_sorting::render(tmpl, &context, "top.html");
     }
 
-    clothing_read_list(session, tmpl).await
+    clothing_read_list(&session, tmpl).await
 }

--- a/src/contents/clothing/read.rs
+++ b/src/contents/clothing/read.rs
@@ -59,8 +59,8 @@ pub async fn clothing_read_list(
     //ServiceSession reference is included in documents::List, so get auth outside of
     //read_list_firestore function.
     let mut context = Context::new();
-    let (tmpl, string_doc_result) = clothing_read_list_inner(session, tmpl, &mut context).await;
-    context.insert("read_list_result", &string_doc_result);
+    let (tmpl, doc_result_map) = clothing_read_list_inner(session, tmpl, &mut context).await;
+    context.insert("doc_result_map", &doc_result_map);
 
     saint_sorting::render(tmpl, &context, "clothing.html")
 }

--- a/src/contents/clothing/read.rs
+++ b/src/contents/clothing/read.rs
@@ -1,10 +1,4 @@
-use crate::{
-    firestore::{
-        firestore_error,
-        read::{read_firestore, read_list_firestore},
-    },
-    *,
-};
+use crate::{firestore::read::read_list_firestore, *};
 use firestore_db_and_auth::documents;
 use std::collections::HashMap;
 
@@ -13,7 +7,7 @@ fn split_name_to_id(name: &str) -> &str {
     split_name[0]
 }
 
-pub async fn clothing_read(
+/*pub async fn clothing_read(
     session: Session,
     params: web::Form<FormParamsDbRead>,
     tmpl: web::Data<Tera>,
@@ -50,7 +44,7 @@ pub async fn clothing_read(
     context.insert("read_result", &json_read_result.to_string());
 
     saint_sorting::render(tmpl, &context, "clothing.html")
-}
+}*/
 
 pub async fn clothing_read_list(
     session: &Session,
@@ -69,7 +63,7 @@ pub async fn clothing_read_list_inner<'a>(
     session: &Session,
     tmpl: web::Data<Tera>,
     context: &mut Context,
-) -> (web::Data<Tera>, HashMap<String, String>) {
+) -> (web::Data<Tera>, HashMap<String, Vec<String>>) {
     //read_list_firestore function.
     let cred = Credentials::from_file("firebase-service-account.json").unwrap();
     let auth = ServiceSession::new(cred).unwrap();
@@ -83,7 +77,7 @@ pub async fn clothing_read_list_inner<'a>(
             Ok(dto_list) => dto_list,
         };
 
-    let mut doc_result_map: HashMap<String, String> = HashMap::new();
+    let mut doc_result_map: HashMap<String, Vec<String>> = HashMap::new();
     for doc_result in read_list_result {
         let (doc, metadata) = match doc_result {
             Err(_e) => {
@@ -99,9 +93,12 @@ pub async fn clothing_read_list_inner<'a>(
         string_doc_values = string_doc_values
             .trim_matches('{')
             .trim_matches('}')
-            .replace(",", "\n")
             .to_string();
-        doc_result_map.insert(doc_id.to_string(), string_doc_values);
+        let doc_values = string_doc_values
+            .split(',')
+            .map(|str| str.to_string())
+            .collect();
+        doc_result_map.insert(doc_id.to_string(), doc_values);
     }
 
     (tmpl, doc_result_map)

--- a/src/contents/clothing/read.rs
+++ b/src/contents/clothing/read.rs
@@ -52,7 +52,7 @@ pub async fn clothing_read(
 }
 
 pub async fn clothing_read_list(
-    session: Session,
+    session: &Session,
     tmpl: web::Data<Tera>,
 ) -> actix_web::Result<HttpResponse, Error> {
     //ServiceSession reference is included in documents::List, so get auth outside of
@@ -64,7 +64,7 @@ pub async fn clothing_read_list(
 }
 
 pub async fn clothing_read_list_inner<'a>(
-    session: Session,
+    session: &Session,
     tmpl: web::Data<Tera>,
     context: &mut Context,
 ) -> web::Data<Tera> {
@@ -103,7 +103,7 @@ pub async fn clothing_read_list_inner<'a>(
 }
 
 pub async fn clothing_read_list_render(
-    session: Session,
+    session: &Session,
     tmpl: web::Data<Tera>,
     context: &mut Context,
 ) -> actix_web::Result<HttpResponse, Error> {

--- a/src/contents/clothing/read.rs
+++ b/src/contents/clothing/read.rs
@@ -9,7 +9,7 @@ use firestore_db_and_auth::documents;
 
 fn split_name_to_id(name: &str) -> &str {
     let split_name: Vec<&str> = name.rsplit('/').collect();
-    return split_name[0];
+    split_name[0]
 }
 
 pub async fn clothing_read(
@@ -82,7 +82,7 @@ pub async fn clothing_read_list(
         };
         let doc_id = split_name_to_id(&metadata.name);
         let json_doc = serde_json::to_value(&doc).unwrap();
-        string_doc_result.push_str(&doc_id);
+        string_doc_result.push_str(doc_id);
         string_doc_result.push_str(&json_doc.to_string());
     }
     //println!("{string_doc_result}");

--- a/src/contents/clothing/read.rs
+++ b/src/contents/clothing/read.rs
@@ -94,7 +94,7 @@ pub async fn clothing_read_list_inner<'a>(
         let json_doc = serde_json::to_value(&doc).unwrap();
         string_doc_result.push_str(doc_id);
         string_doc_result.push_str(&json_doc.to_string());
-        string_doc_result.push_str("\n");
+        string_doc_result.push('\n');
     }
     //println!("{string_doc_result}");
     context.insert("read_list_result", &string_doc_result);

--- a/src/contents/clothing/write.rs
+++ b/src/contents/clothing/write.rs
@@ -46,7 +46,7 @@ pub async fn clothing_write(
             return saint_sorting::render(tmpl, &context, "top.html");
         }
     }
-    clothing_read_list_render(session, tmpl, &mut context).await
+    clothing_read_list_render(&session, tmpl, &mut context).await
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/firestore/delete.rs
+++ b/src/firestore/delete.rs
@@ -2,7 +2,7 @@ use super::firestore_error::FireStoreError;
 use crate::*;
 
 pub async fn delete_firestore(
-    session: Session,
+    session: &Session,
     document_id: String,
 ) -> actix_web::Result<(), FireStoreError> {
     let user_id = match session.get::<Uuid>("user_id")? {

--- a/src/firestore/read.rs
+++ b/src/firestore/read.rs
@@ -19,10 +19,10 @@ pub async fn read_firestore<T: for<'a> Deserialize<'a>>(
     Ok(dto)
 }
 
-pub async fn read_list_firestore<T: for<'a> Deserialize<'a>>(
-    session: Session,
-    auth: &ServiceSession,
-) -> Result<documents::List<T, firestore_db_and_auth::ServiceSession>, FireStoreError> {
+pub async fn read_list_firestore<'b, T: for<'a> Deserialize<'a>>(
+    session: &'b Session,
+    auth: &'b ServiceSession,
+) -> Result<documents::List<'b, T, firestore_db_and_auth::ServiceSession>, FireStoreError> {
     let user_id = match session.get::<Uuid>("user_id")? {
         None => return Err(FireStoreError::SessionGet(String::from("unauthorized"))),
         Some(i) => i.to_string(),

--- a/src/firestore/read.rs
+++ b/src/firestore/read.rs
@@ -1,7 +1,7 @@
 use super::firestore_error::FireStoreError;
 use crate::*;
 
-pub async fn read_firestore<T: for<'a> Deserialize<'a>>(
+/*pub async fn read_firestore<T: for<'a> Deserialize<'a>>(
     session: &Session,
     auth: &ServiceSession,
     document_id: &str,
@@ -17,7 +17,7 @@ pub async fn read_firestore<T: for<'a> Deserialize<'a>>(
     };
 
     Ok(dto)
-}
+}*/
 
 pub async fn read_list_firestore<'b, T: for<'a> Deserialize<'a>>(
     session: &'b Session,

--- a/src/firestore/read.rs
+++ b/src/firestore/read.rs
@@ -2,7 +2,7 @@ use super::firestore_error::FireStoreError;
 use crate::*;
 
 pub async fn read_firestore<T: for<'a> Deserialize<'a>>(
-    session: Session,
+    session: &Session,
     auth: &ServiceSession,
     document_id: &str,
 ) -> Result<T, FireStoreError> {

--- a/src/firestore/write.rs
+++ b/src/firestore/write.rs
@@ -3,7 +3,7 @@ use crate::*;
 use super::firestore_error::FireStoreError;
 
 pub async fn write_firestore<T>(
-    session: Session,
+    session: &Session,
     document_id: String,
     obj: &T,
 ) -> Result<(), FireStoreError>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use actix_session::{storage::CookieSessionStore, Session, SessionMiddleware};
 use actix_web::{
     cookie::Key,
-    error,
     middleware::Logger,
     web::{self, Data},
     App, Error, HttpResponse, HttpServer,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,7 @@ use auth::page_view::{top_signin, top_signup};
 use contents::{
     book::page_view::book,
     clothing::{
-        delete::clothing_delete,
-        page_view::clothing,
-        read::{clothing_read, clothing_read_list},
+        delete::clothing_delete, page_view::clothing, read::clothing_read_list,
         write::clothing_write,
     },
 };
@@ -71,8 +69,6 @@ async fn main() -> std::io::Result<()> {
                     .route("/book", web::get().to(book))
                     .route("/clothing", web::get().to(clothing))
                     .route("/clothing/write", web::post().to(clothing_write))
-                    .route("/clothing/read", web::post().to(clothing_read))
-                    .route("/clothing/read_list", web::get().to(clothing_read_list))
                     .route("/clothing/delete", web::post().to(clothing_delete)),
             )
     })

--- a/templates/clothing.html
+++ b/templates/clothing.html
@@ -10,18 +10,21 @@
 <body>
   <header>
     <h1>Clothing</h1>
-    {% if failure_message %}
-    <p>{{failure_message}}<p>
+    {% if failure_message_write%}
+    <p>{{failure_message_write}}</p>
     {% endif %}
-    {% if read_list_result %}
-    <p>You have these clothing.</p>
-    <p>{{read_list_result}}<p>
+    {% if failure_message_read %}
+    <p>{{failure_message_read}}</p>
+    {% endif %}
+    {% if failure_message_delete%}
+    <p>{{failure_message_delete}}</p>
     {% endif %}
   </header>
 
   <main>
     <div id="content">
       <div id="main">
+
         <!-- delete -->
         <h2>delete documents from firestore</h2>
         <form class="form-horizontal" id="simpleForm" method="post" action="/app/clothing/delete">
@@ -31,6 +34,14 @@
           </div>
           <button type="submit">Delete</button>
         </form>
+
+        <!--read_list result-->
+        <h2>You have these clothings...</h2>
+        {% if read_list_result %}
+        <p>{{read_list_result}}</p>
+        {% else %}
+        <p>No data!</p>
+        {% endif %}
       </div>
 
       <nav>

--- a/templates/clothing.html
+++ b/templates/clothing.html
@@ -13,10 +13,6 @@
     {% if failure_message %}
     <p>{{failure_message}}<p>
     {% endif %}
-    {% if read_result %}
-    <p>clothing_read</p>
-    <p>{{read_result}}<p>
-    {% endif %}
     {% if read_list_result %}
     <p>You have these clothing.</p>
     <p>{{read_list_result}}<p>
@@ -25,119 +21,119 @@
 
   <main>
     <div id="content">
-    <div id="main">
-  <!-- delete -->
-    <h2>delete documets from firestore</h2>
-    <form class="form-horizontal" id="simpleForm" method="post" action="/app/clothing/delete">
-      <div class="form-group">
-        <label for="document_id">Document ID</label>
-        <input name="document_id" id="document_id" type="text">
+      <div id="main">
+        <!-- delete -->
+        <h2>delete documents from firestore</h2>
+        <form class="form-horizontal" id="simpleForm" method="post" action="/app/clothing/delete">
+          <div class="form-group">
+            <label for="document_id">Document ID</label>
+            <input name="document_id" id="document_id" type="text">
+          </div>
+          <button type="submit">Delete</button>
+        </form>
       </div>
-      <button type="submit">Delete</button>
-    </form>
-  <!-- read -->
-      <h2>read documets from firestore</h2>
-      <form class="form-horizontal" id="simpleForm" method="post" action="/app/clothing/read">
-        <div class="form-group">
-          <label for="document_id">Document ID</label>
-          <input name="document_id" id="document_id" type="text">
-        </div>
-        <button type="submit">Read</button>
-      </form>
-    <br>
-      <form method="get" action="/app/clothing/read_list">
-        <button type="submit">Read List</button>
-      </form>
-    </div>
 
-    <nav>
-      <ul>
-		<li>
-		  <label class="open" for="pop-up" id="pop-up-label">Add</label>
-		  <input type="checkbox" id="pop-up">
-		  <div class="overlay">
-			<div class="window">
-			  <label class="close" for="pop-up" id="pop-up-close">close</label>
-		<div>
-		  <form class="form-horizontal" method="post" action="/app/clothing/write">
-		  <!-- input clothing name as document id -->
-			<div class="form-group">
-			  <label for="document_id">New Clothing Name</label>
-			  <input name="document_id" id="w_document_id" type="text">
-			</div>
-		  <!-- brand -->
-			<div class="form-group">
-			  <label for="brand">brand</label>
-			  <input name="brand" id="brand" type="text" class="form-control">
-			</div>
-		  <!-- year -->
-			<div class="form-group">
-			  <label for="year">year</label>
-			  <input name="year" id="year" type="text" class="form-control">
-			</div>
-		  <!--  month-->
-			<div class="form-group">
-			  <label for="month">month</label>
-			  <!-- <input name="month" id="month" type="number"> -->
-			  <select id="month" name="month" class="form-control">
-				<option value=""></option>
-				<option value="1">1</option>
-				<option value="2">2</option>
-				<option value="3">3</option>
-				<option value="4">4</option>
-				<option value="5">5</option>
-				<option value="6">6</option>
-				<option value="7">7</option>
-				<option value="8">8</option>
-				<option value="9">9</option>
-				<option value="10">10</option>
-				<option value="11">11</option>
-				<option value="12">12</option>
-			  </select>
-			</div>
-		  <!--season  -->
-			<div class="form-group">
-			  <label for="season">season</label>
-			  <select id="season" name="season" class="form-control">
-				<option value=""></option>
-				<option value="Spring">Spring</option>
-				<option value="Summer">Summer</option>
-				<option value="Autumn">Autumn</option>
-				<option value="Winter">Winter</option>
-			  </select>
-			</div>
-		  <!-- shop name -->
-			<div class="form-group">
-			  <label for="shop">shopName/place</label>
-			  <input name="shop" id="shop" type="text" class="form-control">
-			</div>
-		  <!-- category -->
-			<div class="form-group">
-			  <label for="category">Category</label>
-			  <select id="category" name="category" class="form-control">
-				<option value=""></option>
-				<option value="tops">tops</option>
-				<option value="bottoms">bottoms</option>
-				<option value="outer">Outer</option>
-				<option value="socks">Socks</option>
-				<option value="bag">Bag</option>
-				<option value="accessories">Accessories</option>
-			  </select>
-			</div>
-			<button type="submit" id="write_button">Ok!</button>
-		  </form>
-		  <!--      <button type="submit">Write</button> -->
-		</div>
-		</li>
-		<br>
-		<li><a href="https://localhost:8080/app/book">book</li>
-		<br>
-        <li><a href="#">Setting</li>
-		<br>
-        <li><a href="https://localhost:8080/app/top">Top Page</li>
-      </ul>
-    </nav>
-  </div>
+      <nav>
+        <ul>
+          <li>
+            <label class="open" for="pop-up" id="pop-up-label">Add</label>
+            <input type="checkbox" id="pop-up">
+
+            <div class="overlay">
+              <div class="window">
+                <label class="close" for="pop-up" id="pop-up-close">close</label>
+
+                <div>
+                  <form class="form-horizontal" method="post" action="/app/clothing/write">
+
+                    <!-- input clothing name as document id -->
+                    <div class="form-group">
+                      <label for="document_id">New Clothing Name</label>
+                      <input name="document_id" id="w_document_id" type="text">
+                    </div>
+
+                    <!-- brand -->
+                    <div class="form-group">
+                      <label for="brand">brand</label>
+                      <input name="brand" id="brand" type="text" class="form-control">
+                    </div>
+
+                    <!-- year -->
+                    <div class="form-group">
+                      <label for="year">year</label>
+                      <input name="year" id="year" type="text" class="form-control">
+                    </div>
+
+                    <!--  month-->
+                    <div class="form-group">
+                      <label for="month">month</label>
+
+                      <!-- <input name="month" id="month" type="number"> -->
+                      <select id="month" name="month" class="form-control">
+                        <option value=""></option>
+                        <option value="1">1</option>
+                        <option value="2">2</option>
+                        <option value="3">3</option>
+                        <option value="4">4</option>
+                        <option value="5">5</option>
+                        <option value="6">6</option>
+                        <option value="7">7</option>
+                        <option value="8">8</option>
+                        <option value="9">9</option>
+                        <option value="10">10</option>
+                        <option value="11">11</option>
+                        <option value="12">12</option>
+                      </select>
+                    </div>
+
+                    <!--season  -->
+                    <div class="form-group">
+                      <label for="season">season</label>
+                      <select id="season" name="season" class="form-control">
+                        <option value=""></option>
+                        <option value="Spring">Spring</option>
+                        <option value="Summer">Summer</option>
+                        <option value="Autumn">Autumn</option>
+                        <option value="Winter">Winter</option>
+                      </select>
+                    </div>
+
+                    <!-- shop name -->
+                    <div class="form-group">
+                      <label for="shop">shopName/place</label>
+                      <input name="shop" id="shop" type="text" class="form-control">
+                    </div>
+
+                    <!-- category -->
+                    <div class="form-group">
+                      <label for="category">Category</label>
+                      <select id="category" name="category" class="form-control">
+                        <option value=""></option>
+                        <option value="tops">tops</option>
+                        <option value="bottoms">bottoms</option>
+                        <option value="outer">Outer</option>
+                        <option value="socks">Socks</option>
+                        <option value="bag">Bag</option>
+                        <option value="accessories">Accessories</option>
+                      </select>
+                    </div>
+
+                    <button type="submit" id="write_button">Ok!</button>
+                  </form>
+                <!--      <button type="submit">Write</button> -->
+                </div>
+              </div>
+            </div>
+            <br>
+            <li><a href="https://localhost:8080/app/book">book</li>
+            <br>
+            <li><a href="#">Setting</li>
+            <br>
+            <li><a href="https://localhost:8080/app/top">Top Page</li>
+          </li>
+        </ul>
+      </nav>
+    </div>
   </main>
 <!--
   <footer>

--- a/templates/clothing.html
+++ b/templates/clothing.html
@@ -13,7 +13,14 @@
     {% if failure_message %}
     <p>{{failure_message}}<p>
     {% endif %}
+    {% if read_result %}
+    <p>clothing_read</p>
+    <p>{{read_result}}<p>
+    {% endif %}
+    {% if read_list_result %}
     <p>You have these clothing.</p>
+    <p>{{read_list_result}}<p>
+    {% endif %}
   </header>
 
   <main>
@@ -113,14 +120,14 @@
 				<option value="bottoms">bottoms</option>
 				<option value="outer">Outer</option>
 				<option value="socks">Socks</option>
-				<option value="bag">Bag</option> 
-				<option value="accessories">Accessories</option> 
+				<option value="bag">Bag</option>
+				<option value="accessories">Accessories</option>
 			  </select>
 			</div>
 			<button type="submit" id="write_button">Ok!</button>
 		  </form>
 		  <!--      <button type="submit">Write</button> -->
-		</div> 
+		</div>
 		</li>
 		<br>
 		<li><a href="https://localhost:8080/app/book">book</li>

--- a/templates/clothing.html
+++ b/templates/clothing.html
@@ -37,8 +37,13 @@
 
         <!--read_list result-->
         <h2>You have these clothings...</h2>
-        {% if read_list_result %}
-        <p>{{read_list_result}}</p>
+        {% if doc_result_map %}
+          {% for key, value in doc_result_map %}
+            <details>
+              <summary>{{key}}</summary>
+                {{value}}
+            </details>
+          {% endfor %}
         {% else %}
         <p>No data!</p>
         {% endif %}

--- a/templates/clothing.html
+++ b/templates/clothing.html
@@ -38,10 +38,12 @@
         <!--read_list result-->
         <h2>You have these clothings...</h2>
         {% if doc_result_map %}
-          {% for key, value in doc_result_map %}
+          {% for key, doc_values in doc_result_map %}
             <details>
               <summary>{{key}}</summary>
-                {{value}}
+              {% for value in doc_values %}
+                {{value}} <br>
+              {% endfor %}
             </details>
           {% endfor %}
         {% else %}

--- a/templates/css/clothing.css
+++ b/templates/css/clothing.css
@@ -14,7 +14,7 @@ h1 {
 h2 {
     color: #000000;
 }
-    
+
 header p {
     line-height: 2em;
 	color: #ffffff;
@@ -28,14 +28,14 @@ header, div#main, nav, footer {
 header {
     background-color: #191970;
 }
-    
+
 div#content {
     background-color: #f0f8ff;
     width: 760px;
     overflow: auto;
 /*	margin: 0 auto;*/
 }
-  
+
 div#main {
     background-color: #f0f8ff;
     width: 580px;
@@ -53,15 +53,15 @@ nav {
 nav a:link {
   color: #ffffff;
   }
-    
+
   /*nav a:visited {
     color: #ccffcc;
     }
-    
+
     nav a:hover {
     color: #339933;
     }
-    
+
     nav li {
     line-height: 2em;
     } */
@@ -69,7 +69,7 @@ label#pop-up-label{
 	color: #ffffff;
 }
 nav label{
-	color: #00000;
+	color: #000000;
 }
 /*---------------
 /* write pop-up */


### PR DESCRIPTION
# Description

1.  Refactored Firestore/clothing read/write/delete functions:
     1-1. Replaced errors in write/delete pages to show an error message.
　 1-2. Modified actix_session argument types to references, so that each function can be called in other functions. 

2.  Show the clothing_read_list function result in the clothing page on default.
3.  Update clothing page UIs.

I think a thirty-four test is not needed for this function currently, so I leave it.